### PR TITLE
Added 'avif' to list of valid image attachment filetypes

### DIFF
--- a/src/Utili.Bot/Extensions/Disqord/MessageExtensions.cs
+++ b/src/Utili.Bot/Extensions/Disqord/MessageExtensions.cs
@@ -25,7 +25,8 @@ public static class MessageExtensions
             "png",
             "jpg",
             "jpeg",
-            "webp"
+            "webp",
+            "avif"
         };
 
         var filenames = message.Attachments.Select(x => x.FileName).ToList();


### PR DESCRIPTION
Saw the Bot was filtering out my screenshots, so I added the "avif" filetype to the list of valid attachments when filtering for images. 